### PR TITLE
feat(uv): run sync version of luv when outside of tasks

### DIFF
--- a/lua/nio/uv.lua
+++ b/lua/nio/uv.lua
@@ -111,7 +111,7 @@ nio.uv = {}
 
 ---@nodoc
 local function add(name, argc)
-  local success, ret = pcall(tasks.wrap, vim.loop[name], argc)
+  local success, ret = pcall(tasks.wrap, vim.loop[name], argc, { strict = true })
 
   if not success then
     error("Failed to add function with name " .. name)

--- a/lua/nio/uv.lua
+++ b/lua/nio/uv.lua
@@ -166,6 +166,5 @@ add("listen", 3)
 -- add('read_start', 2) -- do not do this one, the callback is made multiple times
 add("write", 3)
 add("write2", 4)
-add("shutdown", 2)
 
 return nio.uv


### PR DESCRIPTION
After [this commit](https://github.com/nvim-neotest/nvim-nio/commit/230439dee66fd58e086c4172d8f5280cf40fedd7), functions defined in `nio.uv` do not work when called outside of a task (async environment).

Although I do agree with this design decision (which also matches the type annotations), I couldn't live without them being callable in sync from a practical standpoint.

With this PR, the function defined in `add` wraps the call to `tasks.wrap` and branches out to call sync version of `vim.loop` functions when not in a task, and manipulate the result to match that of wrapped calls (`string?: err_msg, ...?: result`).

If you @rcarriga don't agree with this approach, feel free to reject this PR tho.

I also added a few fixes.
- fix(uv): shutdown is defined twice for no reason
- docs(uv): hardcode that `strict = true` in nio.uv