### PR TITLE
docs(luacats): prevent lua-ls `redundant-return-value` warning

### DIFF
--- a/lua/nio/init.lua
+++ b/lua/nio/init.lua
@@ -78,7 +78,7 @@ end
 ---
 --- This is useful for APIs where users don't want to create async
 --- contexts but which are still used in async contexts internally.
----@param func async fun(...)
+---@param func async function
 ---@param argc? integer The number of arguments of func. Must be included if there are arguments.
 function nio.create(func, argc)
   return tasks.create(func, argc)


### PR DESCRIPTION
Hey :wave: 

we run lua-language-server to statically type check our code in CI.
It fails on warnings when we pass in a function that returns something to `nio.create`.

This is because the luaCATS annotation specifies `---@param fun(...)` (without a return value).
Specifying `function` instead should prevent this.