### PR TITLE
fix(process): return exit code instead of signal

### DIFF
--- a/lua/nio/process.lua
+++ b/lua/nio/process.lua
@@ -93,7 +93,7 @@ function nio.process.run(opts)
     verbatim = opts.verbatim,
     detached = opts.detached,
     hide = opts.hide,
-  }, function(_, code)
+  }, function(code, _)
     exit_code_future.set(code)
   end)
 


### PR DESCRIPTION
It looks like the first argument of `on_exit` is the exit code of the process.

`:h uv.spawn()`

```txt
uv.spawn({path}, {options}, {on_exit})                              *uv.spawn()*

                Parameters:
                - `path`: `string`
                - `options`: `table` (see below)
                - `on_exit`: `callable`
                  - `code`: `integer`
                  - `signal`: `integer`
```