### PR TITLE
fix: replace tbl_flatten to flatten():totable()

### DIFF
--- a/lua/nio/logger.lua
+++ b/lua/nio/logger.lua
@@ -36,7 +36,7 @@ function Logger.new(filename, opts)
   end)()
 
   local function path_join(...)
-    return table.concat(vim.tbl_flatten({ ... }), path_sep)
+    return table.concat(vim.iter({ ... }):flatten():totable(), path_sep)
   end
 
   logger._level = opts.level or vim.log.levels.WARN
@@ -52,7 +52,7 @@ function Logger.new(filename, opts)
   local log_info = vim.loop.fs_stat(logger._filename)
   if log_info and log_info.size > LARGE then
     local warn_msg =
-      string.format("Nio log is large (%d MB): %s", log_info.size / (1000 * 1000), logger._filename)
+        string.format("Nio log is large (%d MB): %s", log_info.size / (1000 * 1000), logger._filename)
     vim.notify(warn_msg, vim.log.levels.WARN)
   end
 

--- a/lua/nio/logger.lua
+++ b/lua/nio/logger.lua
@@ -1,3 +1,5 @@
+local util = require("nio.util")
+
 local loggers = {}
 
 local log_date_format = "%FT%H:%M:%SZ%z"
@@ -36,7 +38,7 @@ function Logger.new(filename, opts)
   end)()
 
   local function path_join(...)
-    return table.concat(vim.iter({ ... }):flatten():totable(), path_sep)
+    return table.concat(util.tbl_flatten({ ... }), path_sep)
   end
 
   logger._level = opts.level or vim.log.levels.WARN

--- a/lua/nio/util.lua
+++ b/lua/nio/util.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.tbl_flatten(t)
-  return vim.fn.has("nvim-0.10") == 1 and vim.iter(t):flatten(math.huge):totable()
+  return vim.fn.has("nvim-0.11") == 1 and vim.iter(t):flatten(math.huge):totable()
       or vim.tbl_flatten(t)
 end
 

--- a/lua/nio/util.lua
+++ b/lua/nio/util.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+function M.tbl_flatten(t)
+  return vim.fn.has("nvim-0.10") == 1 and vim.iter(t):flatten(math.huge):totable()
+      or vim.tbl_flatten(t)
+end
+
+return M

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -1,6 +1,7 @@
 -- TODO: A lot of this is private code from minidoc, which could be removed if made public
 
 local minidoc = require("mini.doc")
+local util = require("nio.util")
 
 local H = {}
 --stylua: ignore start
@@ -107,7 +108,7 @@ H.default_input = function()
     table.insert(res, files)
   end
 
-  return vim.iter(res):flatten():totable()
+  return util.tbl_flatten(res)
 end
 
 -- Parsing --------------------------------------------------------------------
@@ -297,7 +298,7 @@ H.toc_insert = function(s)
     toc_entry:clear_lines()
   end
 
-  for _, l in ipairs(vim.iter(toc_lines):flatten():totable()) do
+  for _, l in ipairs(util.tbl_flatten(toc_lines)) do
     s:insert(l)
   end
 end
@@ -620,7 +621,7 @@ H.collect_strings = function(x)
     end
   end, x)
   -- Flatten to only have strings and not table of strings (from `vim.split`)
-  return vim.iter(res):flatten():totable()
+  return util.tbl_flatten(res)
 end
 
 H.file_read = function(path)

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -107,7 +107,7 @@ H.default_input = function()
     table.insert(res, files)
   end
 
-  return vim.tbl_flatten(res)
+  return vim.iter(res):flatten():totable()
 end
 
 -- Parsing --------------------------------------------------------------------
@@ -297,7 +297,7 @@ H.toc_insert = function(s)
     toc_entry:clear_lines()
   end
 
-  for _, l in ipairs(vim.tbl_flatten(toc_lines)) do
+  for _, l in ipairs(vim.iter(toc_lines):flatten():totable()) do
     s:insert(l)
   end
 end
@@ -620,7 +620,7 @@ H.collect_strings = function(x)
     end
   end, x)
   -- Flatten to only have strings and not table of strings (from `vim.split`)
-  return vim.tbl_flatten(res)
+  return vim.iter(res):flatten():totable()
 end
 
 H.file_read = function(path)


### PR DESCRIPTION
Deprecation warnings in v0.10 and v11 nightlies

```
vim.tbl_flatten is deprecated, use vim.iter(…):flatten():totable() instead. :help deprecated
Feature will be removed in Nvim 0.12
```

#17 