### PR TITLE
feat(lsp): add supports_method to `nio.lsp.Client`

### DIFF
--- a/tests/lsp_spec.lua
+++ b/tests/lsp_spec.lua
@@ -93,4 +93,22 @@ describe("lsp client", function()
     assert.False(success)
     assert.Not.Nil(string.find(err, "Client 1 has shut down"))
   end)
+
+  a.it("returns a response for whether a method is supported", function()
+    local expected_result = false
+    local expected_method = "textDocument/diagnostic"
+    local expected_opts = { a = "b" }
+    vim.lsp.get_client_by_id = function(id)
+      return {
+        supports_method = function(method, opts)
+          assert.equals(expected_method, method)
+          assert.same(expected_opts, opts)
+          return expected_result
+        end,
+      }
+    end
+    local client = nio.lsp.get_client_by_id(1)
+    local result = client.supports_method.textDocument_diagnostic(expected_opts)
+    assert.equals(expected_result, result)
+  end)
 end)


### PR DESCRIPTION
The straight way to check whether a method is supported is via `supports_method`. 

[News 0.10.0](https://github.com/neovim/neovim/blob/master/runtime/doc/news-0.10.txt#L244-L248):
> * Dynamic registration of LSP capabilities. An implication of this change is
    that checking a client's `server_capabilities` is no longer a sufficient
    indicator to see if a server supports a feature. Instead use
    `client.supports_method(<method>)`. It considers both the dynamic
    capabilities and static `server_capabilities`.

For example, nvim-jdtls does not have `definitionProvider` in server capabilities. See https://github.com/mfussenegger/nvim-jdtls/issues/589#issuecomment-1821361157.

Relates to https://github.com/nvim-neotest/neotest/issues/425