### PR TITLE
Feature: Kill process on task cancel

### DIFF
--- a/lua/nio/process.lua
+++ b/lua/nio/process.lua
@@ -121,13 +121,15 @@ function nio.process.run(opts)
     return nil, stderr_fd_err
   end
 
+  local signal = function(signal)
+    vim.loop.process_kill(handle, signal)
+  end
+
   ---@type nio.process.Process
   local process
   process = {
     pid = pid_or_error,
-    signal = function(signal)
-      vim.loop.process_kill(handle, signal)
-    end,
+    signal = signal,
     stdin = {
       write = stdin.write,
       fd = stdin_fd,
@@ -144,17 +146,23 @@ function nio.process.run(opts)
       close = stderr.close,
     },
     result = function(close)
-      local result = exit_code_future.wait()
-      local errors = {}
-      if close then
-        errors = process.close()
+      local function _result()
+        local result = exit_code_future.wait()
+        local errors = {}
+        if close then
+          errors = process.close()
+        end
+        return result, errors
       end
-      return result, errors
+
+      task = require("nio").run(_result)
+      task.on_cancel(signal)
     end,
     close = function()
       return { stdin.close(), stdout.close(), stderr.close() }
     end,
   }
+
   return process
 end
 

--- a/lua/nio/process.lua
+++ b/lua/nio/process.lua
@@ -113,7 +113,9 @@ function nio.process.run(opts)
     vim.loop.process_kill(handle, signal)
   end
 
-  task.on_cancel(signal)
+  task.on_cancel(function()
+    signal(15)
+  end)
 
   if not handle then
     return nil, pid_or_error

--- a/lua/nio/process.lua
+++ b/lua/nio/process.lua
@@ -91,19 +91,30 @@ function nio.process.run(opts)
 
   local stdio = { stdin.pipe, stdout.pipe, stderr.pipe }
 
-  local handle, pid_or_error = vim.loop.spawn(cmd, {
-    args = args,
-    stdio = stdio,
-    env = opts.env,
-    cwd = opts.cwd,
-    uid = opts.uid,
-    gid = opts.gid,
-    verbatim = opts.verbatim,
-    detached = opts.detached,
-    hide = opts.hide,
-  }, function(code, _)
-    exit_code_future.set(code)
+  local handle, pid_or_error
+  task = require("nio").run(function()
+    handle, pid_or_error = vim.loop.spawn(cmd, {
+      args = args,
+      stdio = stdio,
+      env = opts.env,
+      cwd = opts.cwd,
+      uid = opts.uid,
+      gid = opts.gid,
+      verbatim = opts.verbatim,
+      detached = opts.detached,
+      hide = opts.hide,
+    }, function(code, _)
+      exit_code_future.set(code)
+    end)
+    exit_code_future.wait()
   end)
+
+  local signal = function(signal)
+    dprint("signalling cancel")
+    vim.loop.process_kill(handle, signal)
+  end
+
+  task.on_cancel(signal)
 
   if not handle then
     return nil, pid_or_error
@@ -119,10 +130,6 @@ function nio.process.run(opts)
   local stderr_fd, stderr_fd_err = stderr.pipe:fileno()
   if not stderr_fd then
     return nil, stderr_fd_err
-  end
-
-  local signal = function(signal)
-    vim.loop.process_kill(handle, signal)
   end
 
   ---@type nio.process.Process
@@ -146,17 +153,12 @@ function nio.process.run(opts)
       close = stderr.close,
     },
     result = function(close)
-      local function _result()
-        local result = exit_code_future.wait()
-        local errors = {}
-        if close then
-          errors = process.close()
-        end
-        return result, errors
+      local result = exit_code_future.wait()
+      local errors = {}
+      if close then
+        errors = process.close()
       end
-
-      task = require("nio").run(_result)
-      task.on_cancel(signal)
+      return result, errors
     end,
     close = function()
       return { stdin.close(), stdout.close(), stderr.close() }

--- a/lua/nio/process.lua
+++ b/lua/nio/process.lua
@@ -110,7 +110,6 @@ function nio.process.run(opts)
   end)
 
   local signal = function(signal)
-    dprint("signalling cancel")
     vim.loop.process_kill(handle, signal)
   end
 

--- a/lua/nio/tasks.lua
+++ b/lua/nio/tasks.lua
@@ -38,6 +38,7 @@ end
 ---@field cancel fun(): nil Cancels the task
 ---@field trace fun(): string Get the stack trace of the task
 ---@field wait async function Wait for the task to finish, returning any result
+---@field on_cancel fun(callback: fun()) Register a callback for when the task is cancelled
 
 ---@class nio.tasks.TaskError
 ---@field message string
@@ -60,6 +61,7 @@ end
 function nio.tasks.run(func, cb)
   local co = coroutine.create(func)
   local cancelled = false
+  local on_cancel
   local step
   local task = { parent = nio.tasks.current_task() }
   if task.parent then
@@ -68,9 +70,16 @@ function nio.tasks.run(func, cb)
   end
   local future = require("nio").control.future()
 
+  function task.on_cancel(callback)
+    on_cancel = callback
+  end
+
   function task.cancel()
     if cancelled or coroutine.status(co) == "dead" then
       return
+    end
+    if on_cancel then
+      on_cancel()
     end
     cancelled = true
     for _, child in pairs(child_tasks[task] or {}) do

--- a/lua/nio/tasks.lua
+++ b/lua/nio/tasks.lua
@@ -71,6 +71,7 @@ function nio.tasks.run(func, cb)
   local future = require("nio").control.future()
 
   function task.on_cancel(callback)
+    dprint("setting on_cancel")
     on_cancel = callback
   end
 
@@ -78,7 +79,9 @@ function nio.tasks.run(func, cb)
     if cancelled or coroutine.status(co) == "dead" then
       return
     end
+    dprint("check for on_cancel")
     if on_cancel then
+      dprint("calling on_cancel")
       on_cancel()
     end
     cancelled = true

--- a/lua/nio/tasks.lua
+++ b/lua/nio/tasks.lua
@@ -75,17 +75,26 @@ function nio.tasks.run(func, cb)
   end
 
   function task.cancel()
-    if cancelled or coroutine.status(co) == "dead" then
+    if cancelled then
       return
     end
+
+    local coroutine_dead = coroutine.status(co) == "dead"
     if on_cancel then
-      on_cancel()
+      if not coroutine_dead then
+        on_cancel()
+      end
+      on_cancel = nil
     end
     cancelled = true
+
     for _, child in pairs(child_tasks[task] or {}) do
       child.cancel()
     end
-    step()
+
+    if not coroutine_dead then
+      step()
+    end
   end
 
   function task.trace()

--- a/lua/nio/tasks.lua
+++ b/lua/nio/tasks.lua
@@ -71,7 +71,6 @@ function nio.tasks.run(func, cb)
   local future = require("nio").control.future()
 
   function task.on_cancel(callback)
-    dprint("setting on_cancel")
     on_cancel = callback
   end
 
@@ -79,9 +78,7 @@ function nio.tasks.run(func, cb)
     if cancelled or coroutine.status(co) == "dead" then
       return
     end
-    dprint("check for on_cancel")
     if on_cancel then
-      dprint("calling on_cancel")
       on_cancel()
     end
     cancelled = true

--- a/tests/process_spec.lua
+++ b/tests/process_spec.lua
@@ -204,4 +204,21 @@ describe("process", function()
     local exit_code = process.result()
     assert.equal(1, exit_code)
   end)
+
+  a.it("cancelling task, cancels loose process", function()
+    local process
+    task = nio.run(function()
+      local pipe = assert(vim.loop.new_pipe())
+      process = assert(nio.process.run({
+        cmd = "cat",
+        stdin = pipe,
+      }))
+      return true
+    end)
+    task.cancel()
+    local result = task.wait()
+    assert.equal(true, result)
+    local exit_code = process.result()
+    assert.equal(0, exit_code)
+  end)
 end)


### PR DESCRIPTION
When a process is started, and a parent task is cancelled, the process is not stopped. Instead the task only ignores the result. This behavior is suboptimal for long-running and expensive processes.

This change
* adds `on_cancel` to `task`: a way to clean up external resources when a task is canceled.
* uses `task` and `on_cancel` in `process.run` to kill the process when a parent task is cancelled.
